### PR TITLE
Display failed workflows in red background

### DIFF
--- a/commit.py
+++ b/commit.py
@@ -23,13 +23,14 @@ def _get(sha):
     jobs = sorted(jobs, key=lambda job: job["workflow_name"] + job["job_name"])
     # dict of workflow -> jobs
     jobs_by_workflow = defaultdict(list)
+    failed_workflows = set()
     failed_jobs = []
     pending_jobs = []
     for job in jobs:
         jobs_by_workflow[job["workflow_name"]].append(job)
-
         if job["conclusion"] in ("failure", "cancelled", "timed_out"):
             failed_jobs.append(job)
+            failed_workflows.add(job["workflow_name"])
         elif job["conclusion"] == None:
             pending_jobs.append(job)
 
@@ -59,6 +60,7 @@ def _get(sha):
         "commit_message_body": commit_message_body,
         "commit": commit,
         "jobs_by_workflow": jobs_by_workflow,
+        "failed_workflows": failed_workflows,
         "failed_jobs": failed_jobs,
         "pending_jobs": pending_jobs,
     }

--- a/templates/commit.html
+++ b/templates/commit.html
@@ -17,7 +17,14 @@
         grid-gap: 10px;
     }
 
-    .workflow-box {
+    .workflow-box-fail {
+        border: 1px solid gray;
+        padding: 10px;
+        border-radius: 5px;
+        background-color: mistyrose;
+    }
+
+    .workflow-box-pass {
         border: 1px solid gray;
         padding: 10px;
         border-radius: 5px;

--- a/templates/commit_body.html
+++ b/templates/commit_body.html
@@ -39,7 +39,7 @@
 
 <div class="workflow-container">
     {% for workflow, jobs in jobs_by_workflow.items() %}
-    {% if any([job in failed_jobs for job in jobs]) %}
+    {% if workflow in failed_workflows %}
     <div class="workflow-box-fail">
     {% else %}
     <div class="workflow-box-pass">

--- a/templates/commit_body.html
+++ b/templates/commit_body.html
@@ -39,7 +39,11 @@
 
 <div class="workflow-container">
     {% for workflow, jobs in jobs_by_workflow.items() %}
-    <div class="workflow-box">
+    {% if any([job in failed_jobs for job in jobs]) %}
+    <div class="workflow-box-fail">
+    {% else %}
+    <div class="workflow-box-pass">
+    {% endif %}
         <h3>{{ workflow }}</h3>
         <ul>
             {% for job in jobs %}

--- a/templates/pull.html
+++ b/templates/pull.html
@@ -17,7 +17,14 @@
         grid-gap: 10px;
     }
 
-    .workflow-box {
+    .workflow-box-fail {
+        border: 1px solid gray;
+        padding: 10px;
+        border-radius: 5px;
+        background-color: mistyrose;
+    }
+
+    .workflow-box-pass {
         border: 1px solid gray;
         padding: 10px;
         border-radius: 5px;


### PR DESCRIPTION
This PR will make it easy to distinguish failing workflows from succeeding ones on the commit/pr page. It will look like the below.

![image](https://user-images.githubusercontent.com/31798555/146570743-78358998-fd31-4db7-b5be-4b0d548322eb.png)