### PR TITLE
Optimize fetch to do it in parallel

### DIFF
--- a/lib/fetchCommit.ts
+++ b/lib/fetchCommit.ts
@@ -5,35 +5,36 @@ import { CommitData } from "./types";
 
 export default async function fetchCommit(sha: string): Promise<CommitData> {
   const rocksetClient = getRocksetClient();
-  const commitQuery = await rocksetClient.queryLambdas.executeQueryLambdaByTag(
-    "commons",
-    "commit_query",
-    "latest",
-    {
-      parameters: [
-        {
-          name: "sha",
-          type: "string",
-          value: sha,
-        },
-      ],
-    }
-  );
-
-  const commitJobsQuery = await rocksetClient.queryLambdas.executeQueryLambda(
-    "commons",
-    "commit_jobs_query",
-    "4ba333d37b875c58",
-    {
-      parameters: [
-        {
-          name: "sha",
-          type: "string",
-          value: sha,
-        },
-      ],
-    }
-  );
+  const [commitQuery, commitJobsQuery] = await Promise.all([
+    rocksetClient.queryLambdas.executeQueryLambdaByTag(
+      "commons",
+      "commit_query",
+      "latest",
+      {
+        parameters: [
+          {
+            name: "sha",
+            type: "string",
+            value: sha,
+          },
+        ],
+      }
+    ),
+    await rocksetClient.queryLambdas.executeQueryLambda(
+      "commons",
+      "commit_jobs_query",
+      "4ba333d37b875c58",
+      {
+        parameters: [
+          {
+            name: "sha",
+            type: "string",
+            value: sha,
+          },
+        ],
+      }
+    ),
+  ]);
 
   const commit = commitQuery.results?.[0].commit;
   const firstLine = commit.message.indexOf("\n");

--- a/lib/fetchHud.ts
+++ b/lib/fetchHud.ts
@@ -7,44 +7,46 @@ export default async function fetchHud(params: HudParams): Promise<{
   jobNames: string[];
 }> {
   const rocksetClient = getRocksetClient();
-  const hudQuery = await rocksetClient.queryLambdas.executeQueryLambda(
-    "commons",
-    "hud_query",
-    "05875f87e51aecd5",
-    {
-      parameters: [
-        {
-          name: "branch",
-          type: "string",
-          value: `refs/heads/${params.branch}`,
-        },
-        {
-          name: "page",
-          type: "int",
-          value: params.page.toString(),
-        },
-      ],
-    }
-  );
-  const commitQuery = await rocksetClient.queryLambdas.executeQueryLambda(
-    "commons",
-    "master_commits",
-    "22dfa1db426dc0f1",
-    {
-      parameters: [
-        {
-          name: "branch",
-          type: "string",
-          value: `refs/heads/${params.branch}`,
-        },
-        {
-          name: "page",
-          type: "int",
-          value: params.page.toString(),
-        },
-      ],
-    }
-  );
+  const [hudQuery, commitQuery] = await Promise.all([
+    rocksetClient.queryLambdas.executeQueryLambda(
+      "commons",
+      "hud_query",
+      "05875f87e51aecd5",
+      {
+        parameters: [
+          {
+            name: "branch",
+            type: "string",
+            value: `refs/heads/${params.branch}`,
+          },
+          {
+            name: "page",
+            type: "int",
+            value: params.page.toString(),
+          },
+        ],
+      }
+    ),
+    rocksetClient.queryLambdas.executeQueryLambda(
+      "commons",
+      "master_commits",
+      "22dfa1db426dc0f1",
+      {
+        parameters: [
+          {
+            name: "branch",
+            type: "string",
+            value: `refs/heads/${params.branch}`,
+          },
+          {
+            name: "page",
+            type: "int",
+            value: params.page.toString(),
+          },
+        ],
+      }
+    ),
+  ]);
 
   const commitsBySha = _.keyBy(commitQuery.results, "sha");
   let results = hudQuery.results;


### PR DESCRIPTION
This makes it fetch the two requests in parallel to save on waiting for 2 round trips. 

Test Plan:
Tested the two pages that use it and it still works.
https://www.internalfb.com/intern/px/p/1Wv2P
