### PR TITLE
Some tweaks to PR view

### DIFF
--- a/lib/fetchPR.ts
+++ b/lib/fetchPR.ts
@@ -4,10 +4,10 @@ import { PRData } from "./types";
 export default async function fetchPR(pr: string): Promise<PRData> {
   const rocksetClient = getRocksetClient();
   const [prQuery, commitHistoryQuery] = await Promise.all([
-    rocksetClient.queryLambdas.executeQueryLambdaByTag(
+    rocksetClient.queryLambdas.executeQueryLambda(
       "commons",
       "pr_query",
-      "latest",
+      "70a7732df6e82401",
       {
         parameters: [
           {
@@ -18,10 +18,10 @@ export default async function fetchPR(pr: string): Promise<PRData> {
         ],
       }
     ),
-    rocksetClient.queryLambdas.executeQueryLambdaByTag(
+    rocksetClient.queryLambdas.executeQueryLambda(
       "commons",
       "pr_commit_history_query",
-      "latest",
+      "03dcb4ad66c079f9",
       {
         parameters: [
           {

--- a/lib/fetchPR.ts
+++ b/lib/fetchPR.ts
@@ -1,34 +1,39 @@
 import getRocksetClient from "./rockset";
 import { PRData } from "./types";
 
-export default async function fetchPR(pr: string): Promise<PRData[]> {
+export default async function fetchPR(pr: string): Promise<{ prData: PRData }> {
   const rocksetClient = getRocksetClient();
-  const PRQuery = await rocksetClient.queryLambdas.executeQueryLambda(
-    "commons",
-    "prs_query",
-    "eea6932288753f6d",
-    {
-      parameters: [
-        {
-          name: "pr",
-          type: "int",
-          value: pr,
-        },
-      ],
-    }
-  );
-  const shaSet = new Set();
-  const results: PRData[] = [];
+  const [prQuery, commitHistoryQuery] = await Promise.all([
+    rocksetClient.queryLambdas.executeQueryLambdaByTag(
+      "commons",
+      "pr_query",
+      "latest",
+      {
+        parameters: [
+          {
+            name: "pr",
+            type: "int",
+            value: pr,
+          },
+        ],
+      }
+    ),
+    rocksetClient.queryLambdas.executeQueryLambdaByTag(
+      "commons",
+      "pr_commit_history_query",
+      "latest",
+      {
+        parameters: [
+          {
+            name: "pr",
+            type: "int",
+            value: pr,
+          },
+        ],
+      }
+    ),
+  ]);
+  const prDataResult = prQuery.results![0];
 
-  (PRQuery.results ?? []).map(({ sha, event_time, commit, title }) => {
-    if (!shaSet.has(sha)) {
-      const shaString = sha as string;
-      const eventTime = event_time as string;
-      const firstLine = commit.indexOf("\n");
-      const commitTitle: string = commit.slice(0, firstLine);
-      shaSet.add(shaString);
-      results.push({ sha: shaString, eventTime, commitTitle, title });
-    }
-  });
-  return results;
+  return { ...prDataResult, shas: commitHistoryQuery.results! };
 }

--- a/lib/fetchPR.ts
+++ b/lib/fetchPR.ts
@@ -1,7 +1,7 @@
 import getRocksetClient from "./rockset";
 import { PRData } from "./types";
 
-export default async function fetchPR(pr: string): Promise<{ prData: PRData }> {
+export default async function fetchPR(pr: string): Promise<PRData> {
   const rocksetClient = getRocksetClient();
   const [prQuery, commitHistoryQuery] = await Promise.all([
     rocksetClient.queryLambdas.executeQueryLambdaByTag(

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -58,10 +58,8 @@ export interface HudParams {
 }
 
 export interface PRData {
-  sha: string;
-  eventTime: string;
-  commitTitle: string;
   title: string;
+  shas: { sha: string; title: string }[];
 }
 
 export function packHudParams(input: any) {

--- a/pages/api/pr/[prNumber].ts
+++ b/pages/api/pr/[prNumber].ts
@@ -3,7 +3,7 @@ import fetchPR from "lib/fetchPR";
 import { PRData } from "lib/types";
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<PRData[]>
+  res: NextApiResponse<PRData>
 ) {
   res.status(200).json(await fetchPR(req.query.prNumber as string));
 }

--- a/pages/pr/[repoOwner]/[repoName]/[prNumber].tsx
+++ b/pages/pr/[repoOwner]/[repoName]/[prNumber].tsx
@@ -37,7 +37,7 @@ function CommitHeader({
   selectedSha: string;
 }) {
   const router = useRouter();
-  const pr = router.query.pr as string;
+  const pr = router.query.prNumber as string;
 
   return (
     <div>
@@ -62,8 +62,8 @@ function Page() {
   const router = useRouter();
 
   let swrKey;
-  if (router.query.pr !== undefined) {
-    swrKey = `/api/pr/${router.query.pr}`;
+  if (router.query.prNumber !== undefined) {
+    swrKey = `/api/pr/${router.query.prNumber}`;
   }
   if (router.query.sha !== undefined) {
     swrKey += `?sha=${router.query.sha}`;

--- a/pages/pr/[repoOwner]/[repoName]/[pr].tsx
+++ b/pages/pr/[repoOwner]/[repoName]/[pr].tsx
@@ -1,5 +1,6 @@
 import CommitStatus from "components/CommitStatus";
 import ErrorBoundary from "components/ErrorBoundary";
+import { PRData } from "lib/types";
 import { useRouter } from "next/router";
 import React from "react";
 import useSWR from "swr";
@@ -28,58 +29,66 @@ function CommitInfo({ sha }: { sha: string }) {
   return <CommitStatus commit={commit} />;
 }
 
-function CommitHeader({ prData }: { prData: any }) {
+function CommitHeader({
+  prData,
+  selectedSha,
+}: {
+  prData: PRData;
+  selectedSha: string;
+}) {
   const router = useRouter();
   const pr = router.query.pr as string;
 
   return (
-    <h2>
+    <div>
       Commit:{" "}
       <select
-        style={{ font: "inherit" }}
+        defaultValue={selectedSha}
         onChange={(e) => {
           router.push(`/pr/pytorch/pytorch/${pr}?sha=${e.target.value}`);
         }}
       >
-        {(prData ?? []).map((commit: any, ind: number) => {
-          return (
-            <option key={ind} value={commit.sha}>
-              {commit.commitTitle +
-                ` (${commit.sha.substr(commit.sha.length - 6)})`}
-            </option>
-          );
-        })}
+        {prData.shas.map(({ sha, title }) => (
+          <option key={sha} value={sha}>
+            {title + ` (${sha.substring(0, 6)})`}
+          </option>
+        ))}
       </select>
-    </h2>
+    </div>
   );
 }
 
 function Page() {
   const router = useRouter();
-  const pr = router.query.pr as string;
 
-  const { data: prData } = useSWR(
-    `/api/pr/${pr}${
-      router.query.sha != null ? `?sha=${router.query.sha}` : ""
-    }`,
-    fetcher,
-    {
-      refreshInterval: 60 * 1000, // refresh every minute
-      // Refresh even when the user isn't looking, so that switching to the tab
-      // will always have fresh info.
-      refreshWhenHidden: true,
-    }
-  );
+  let swrKey;
+  if (router.query.pr !== undefined) {
+    swrKey = `/api/pr/${router.query.pr}`;
+  }
+  if (router.query.sha !== undefined) {
+    swrKey += `?sha=${router.query.sha}`;
+  }
+
+  const { data } = useSWR(swrKey, fetcher, {
+    refreshInterval: 60 * 1000, // refresh every minute
+    // Refresh even when the user isn't looking, so that switching to the tab
+    // will always have fresh info.
+    refreshWhenHidden: true,
+  });
+  const prData = data as PRData | undefined;
+
+  if (prData === undefined) {
+    return <div>Loading...</div>;
+  }
 
   const sha =
-    (router.query.sha as string) ?? (prData != null ? prData[0].sha : null);
-  const prTitle = prData != null ? prData[0].title : "";
+    (router.query.sha as string) ?? prData.shas[prData.shas.length - 1].sha;
   return (
     <div>
-      <h1 id="hud-header">
-        PyTorch PR: <code>{`${prTitle} #${pr}`}</code>
+      <h1>
+        {prData.title} <code>{router.query.pr}</code>
       </h1>
-      <CommitHeader prData={prData} />
+      <CommitHeader prData={prData} selectedSha={sha} />
       <ErrorBoundary>
         <CommitInfo sha={sha} />
       </ErrorBoundary>


### PR DESCRIPTION
I had to change some stuff about the underlying data backend (`pull_request` now only reflects the *latest* state in GH, similar to the GH API), so need to fix up PR data fetching to work with that.

Other minor changes/improvements
- Which commit we're on is actually that important (almost always you want latest) so demoting it from a header element to a regular div.
- The router's query struct is empty pre-hydration, so previously we were sending a bad request on first load, fixed that.
- The <select> element did not have a default value previously, now it reflects the sha you are currently looking at.
- Query parameter was inconsistent (`[pr]` vs. `[prNumber]`).